### PR TITLE
Masquage automatique des saisies manuelles déjà effectuées

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,12 +28,23 @@ foreach ($lignesMisesAJour as $maj) {
 foreach ($toutesLesLignes as $line) {
     $key = $line['CodeDoc'].'|'.$line['NumLig'];
     if (!isset($majExistantes[$key])) {
+        $sortieMvt = $dbBatigest->query("SELECT COUNT(*) AS nb FROM ElementMvtStock WHERE TypeMvt = 'S' AND CodeElem = :codeElem AND Quantite = :qte AND Info = :info", [
+            'codeElem' => $line['CodeElem'],
+            'qte' => $line['Qte'],
+            'info' => $line['CodeDoc']
+        ])->fetch(PDO::FETCH_ASSOC);
+
+        if ($sortieMvt['nb'] > 0) {
+            continue;
+        }
+
         $lignesAMettreAJour[] = [
             'CodeDoc' => $line['CodeDoc'],
             'NumLig' => $line['NumLig'],
             'CodeElem' => $line['CodeElem'],
             'Qte' => $line['Qte'],
         ];
+        
     }
 }
 

--- a/process.php
+++ b/process.php
@@ -63,7 +63,7 @@ try {
                 $typeMvt = 'S';
                 $provenance = 'I';
                 $pa = round($dbBatigest->query("SELECT PA FROM ElementDef WHERE Code = :codeElem", ['codeElem' => $codeElem])->fetch(PDO::FETCH_ASSOC)["PA"], 2);
-                $info = "Bon Intervention [". $codeDoc . "]";
+                $info = $codeDoc;
 
                 $dbBatigest->query("INSERT INTO ElementMvtStock (CodeElem, TypeMvt, Provenance, Date, Quantite, PA, Info, Suivi, TypeOrigine, Origine, Destination) 
                             VALUES (:codeElem, :typeMvt, :provenance, GETDATE(), :quantite, :pa, :info, 0, '', '', '')", [


### PR DESCRIPTION
Le script vérifie si un mouvement de stock pour l'élément XXXX dans le BI YYYYY et en quantité ZZZZ existe. Si tel est le cas, c'est que la ligne a déjà été traitée auparavant, et il n'est donc pas nécessaire de la garder